### PR TITLE
Feature/add full size stat (#34)

### DIFF
--- a/smbclient/__init__.py
+++ b/smbclient/__init__.py
@@ -33,6 +33,7 @@ from smbclient._os import (
     rmdir,
     scandir,
     stat,
+    stat_volume,
     symlink,
     truncate,
     unlink,

--- a/smbprotocol/file_info.py
+++ b/smbprotocol/file_info.py
@@ -832,6 +832,26 @@ class FileStreamInformation(Structure):
         super(FileStreamInformation, self).__init__()
 
 
+class FileFsFullSizeInformation(Structure):
+    """
+    [MS-FSCC] 2.5.4 FileFsFullSizeInformation
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/63768db7-9012-4209-8cca-00781e7322f5
+    """
+
+    INFO_TYPE = InfoType.SMB2_0_INFO_FILESYSTEM
+    INFO_CLASS = FileSystemInformationClass.FILE_FS_FULL_SIZE_INFORMATION
+
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('total_allocation_units', IntField(size=8, unsigned=False)),
+            ('caller_available_units', IntField(size=8, unsigned=False)),
+            ('actual_available_units', IntField(size=8, unsigned=False)),
+            ('sectors_per_unit', IntField(size=4)),
+            ('bytes_per_sector', IntField(size=4)),
+        ])
+        super(FileFsFullSizeInformation, self).__init__()
+
+
 class FileFsObjectIdInformation(Structure):
     """
     [MS-FSCC] 2.5.6 FileFsObjectIdInformation

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -26,6 +26,7 @@ from smbprotocol.file_info import (
     FileNamesInformation,
     FileRenameInformation,
     FileStandardInformation,
+    FileFsFullSizeInformation
 )
 
 from smbprotocol.structure import (
@@ -822,3 +823,37 @@ class TestFileFsVolumeInformation(object):
         assert actual['volume_label_length'].get_value() == 8
         assert actual['supports_objects'].get_value() is False
         assert actual['volume_label'].get_value() == u"café"
+
+
+class TestFileFsFullSizeInformation(object):
+
+    DATA = b"\xa4\x6f\xd6\x01\x00\x00\x00\x00" \
+           b"\x9c\x41\x12\x01\x00\x00\x00\x00" \
+           b"\x9c\x41\x12\x01\x00\x00\x00\x00" \
+           b"\x02\x00\x00\x00" \
+           b"\x00\x02\x00\x00"
+
+    def test_create_message(self):
+        message = FileFsFullSizeInformation()
+        message['total_allocation_units'] = 30830500
+        message['caller_available_units'] = 17973660
+        message['actual_available_units'] = 17973660
+        message['sectors_per_unit'] = 2
+        message['bytes_per_sector'] = 512
+
+        actual = message.pack()
+        assert len(message) == 32
+        assert actual == self.DATA
+
+    def test_parse_message(self):
+        actual = FileFsFullSizeInformation()
+        data = actual.unpack(self.DATA)
+
+        assert len(actual) == 32
+        assert data == b""
+
+        assert actual['total_allocation_units'].get_value() == 30830500
+        assert actual['caller_available_units'].get_value() == 17973660
+        assert actual['actual_available_units'].get_value() == 17973660
+        assert actual['sectors_per_unit'].get_value() == 2
+        assert actual['bytes_per_sector'].get_value() == 512


### PR DESCRIPTION
* Add support for FileFsFullSizeInformation

* remove unnecessary keyword argument

* add doc string

* fix cr

* fix pep8 line too long

* Slight doc tweaks and rename method to stat_volume

* Should also rename the tuple

* Fix base package import

Co-authored-by: DevUser <devuser@hau.com>
Co-authored-by: Jordan Borean <jborean93@gmail.com>